### PR TITLE
Obfuscate at Packager level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## [v2.0.0] - 2020-03-27
+* Updated `parcel-bundler` from `1.12.3` to `1.12.4`
+* Updated `javascript-obfuscator` from `0.18.1` to `0.27.2`
+* Moved processing from `JSAsset` level up to `JSPackager`
+  * Use `this.options.minify` to identify production mode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-obfuscate",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Uses javascript-obfuscator to obfuscate entry files",
   "main": "src/index.js",
   "directories": {
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/jabuco/parcel-plugin-obfuscate#readme",
   "peerDependencies": {
-    "parcel-bundler": "^1.12.3"
+    "parcel-bundler": "^1.12.4"
   },
   "dependencies": {
-    "javascript-obfuscator": "^0.18.1"
+    "javascript-obfuscator": "^0.27.2"
   },
   "devDependencies": {
     "mocha": "^6.2.0",

--- a/src/ObfuscateAsset.js
+++ b/src/ObfuscateAsset.js
@@ -1,35 +1,15 @@
-const { Asset } = require("parcel-bundler");
+const JSAsset = require("parcel-bundler/src/assets/JSAsset");
+const JSPackager = require("parcel-bundler/src/packagers/JSPackager");
 const Obfuscator = require("javascript-obfuscator");
 
-class ObfuscateAsset extends Asset {
-  async transform(v) {
-    const isProd = process.env.NODE_ENV === "production";
-    const options = {
-      debugProtection: isProd,
-      debugProtectionInterval: isProd,
-      log: false,
-      sourceMap: !isProd,
-      sourceMapMode: "separate",
-      target: this.options.target
-    };
-    const compiled = Obfuscator.obfuscate(
-      v || this.contents.toString(),
-      options
-    );
-    return {
-      value: compiled.getObfuscatedCode(),
-      map: compiled.getSourceMap()
-    };
-  }
-  async generate() {
-    const data = await this.transform();
-    const result = [
-      {
-        type: "js",
-        ...data
-      }
-    ];
-    return result;
+class ObfuscatePackager extends JSPackager {
+  async addAsset(asset) {
+    // On production only
+    if (this.options.minify) {
+      asset.generated.js = await Obfuscator.obfuscate(asset.generated.js).getObfuscatedCode();
+    }
+    return super.addAsset(asset);
   }
 }
-module.exports = ObfuscateAsset;
+
+module.exports = ObfuscatePackager;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 module.exports = bundler => {
-  bundler.addAssetType(".js", require.resolve("./ObfuscateAsset"));
+  bundler.addPackager("js", require.resolve("./ObfuscateAsset"));
 };


### PR DESCRIPTION
Hi @peanutbother,

I've made some changes to your repo that may resolve issue #1.

It basically moves obfuscation from the JSAsset level up to the JSPackager level, thus taking action later in the lifecycle (and should work with or without Electron 🤞 ). For more details, please see the [CHANGELOG](https://github.com/annachu/parcel-plugin-obfuscate/blob/jspackager/CHANGELOG.md).

This was able to pass the tests you wrote and was able to properly garble my large production JS (while leaving my development JS alone) 😁. 

I've published a copy of this to NPM as [@raposify/parcel-plugin-obfuscate](https://www.npmjs.com/package/@raposify/parcel-plugin-obfuscate) if you want to give this a try first.
